### PR TITLE
Set max_cpu to 60.

### DIFF
--- a/conf/metagenlab.config
+++ b/conf/metagenlab.config
@@ -4,7 +4,7 @@ params {
     config_profile_contact     = 'Farid chaabane (github: @farchaab; email: farid.chaabane@chuv.ch)'
 
     max_memory                 = 1.TB
-    max_cpus                   = 120
+    max_cpus                   = 60
     max_time                   = 120.h
 
 }

--- a/conf/metagenlab.config
+++ b/conf/metagenlab.config
@@ -25,6 +25,11 @@ apptainer {
 cleanup = true
 
 process {
+    resourceLimits = [
+        memory: 1.TB,
+        cpus: 60,
+        time: 120.h
+    ]
     maxRetries = 3
     withLabel:process_single {
         queue  = "short"


### PR DESCRIPTION
Jobs are limited to 60 CPUs.
We also set the `resourceLimits` which is the new way of specifying resource limits, see https://nf-co.re/docs/usage/getting_started/configuration#max-resources
