### PR TITLE
Use short queue for process_high jobs on obelix.

### DIFF
--- a/conf/metagenlab.config
+++ b/conf/metagenlab.config
@@ -40,9 +40,9 @@ process {
     withLabel:process_medium {
         queue  = "short"
     }
-
     withLabel:process_high {
-        queue  = "long"
+        time   = { 12.h  * task.attempt }
+        queue  = { task.time > 12.h ? 'long' : 'short' }
     }
     withLabel:process_long {
         queue  = "long"


### PR DESCRIPTION
12 hours is enough for most `process_high` jobs, which is normally set to 16hours. With this PR, we limit `process_high` jobs to 12 hours and use the short queue (on the first attempt). This is better on obelix as the long queue is meant for longer jobs and has a limitation on the number of CPUs that can be used by the total of running jobs in the long queue. So this can lead to only half of obelix being used when all pending jobs are in the long queue.